### PR TITLE
add in a bufenter listener to trigger a didFocusTextDocument

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -10,21 +10,10 @@ export namespace ExecuteClientCommand {
   );
 }
 
-// TODO not implimented
-export namespace MetalsStatus {
-  export const type = new NotificationType<MetalsStatusParams, void>(
-    "metals/status"
+export namespace MetalsDidFocus {
+  export const type = new NotificationType<string, void>(
+    "metals/didFocusTextDocument"
   );
-}
-
-// TODO not implimented
-export namespace MetalsSlowTask {
-  export const type = new RequestType<
-    MetalsSlowTaskParams,
-    MetalsSlowTaskResult,
-    void,
-    void
-  >("metals/slowTask");
 }
 
 export namespace MetalsInputBox {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,7 @@ import { Commands } from "./commands";
 import {
   ConfigurationTarget,
   workspace,
-  WorkspaceConfiguration,
-  commands,
-  StatusBarItem
+  WorkspaceConfiguration
 } from "coc.nvim";
 import * as path from "path";
 import { ChildProcessPromise } from "promisify-child-process";


### PR DESCRIPTION
This addresses https://github.com/scalameta/metals/issues/1258 in Metals by adding an event listener on `BufWinEnter` to know when we jump back into a buffer. This was done primarily for worksheets. Now, when you leave the buffer and re-enter, worksheet evaluations will work as expected.