### PR TITLE
catch coursier err in a nicer way and update recommended mappings

### DIFF
--- a/coc-mappings.vim
+++ b/coc-mappings.vim
@@ -12,9 +12,8 @@
 " If you're curious how to share this or your .vimrc with both vim and nvim,
 " you can find a great article here about this https://neovim.io/doc/user/nvim.html#nvim-from-vim
 "
-" Finally, keep in mind that these are "suggested" settings. Play around with them,
-" change them to your liking etc.
-
+" Finally, keep in mind that these are "suggested" settings. Play around with them
+" and change them to your liking.
 
 " if hidden is not set, TextEdit might fail.
 set hidden
@@ -43,6 +42,7 @@ inoremap <silent><expr> <TAB>
       \ coc#refresh()
 inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
 
+" Used in the tab autocompletion for coc
 function! s:check_back_space() abort
   let col = col('.') - 1
   return !col || getline('.')[col - 1]  =~# '\s'
@@ -54,8 +54,6 @@ inoremap <silent><expr> <c-space> coc#refresh()
 " Use <cr> to confirm completion, `<C-g>u` means break undo chain at current position.
 " Coc only does snippet and additional edit on confirm.
 inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
-" Or use `complete_info` if your vim support it, like:
-" inoremap <expr> <cr> complete_info()["selected"] != "-1" ? "\<C-y>" : "\<C-g>u\<CR>"
 
 " Use `[g` and `]g` to navigate diagnostics
 nmap <silent> [g <Plug>(coc-diagnostic-prev)
@@ -91,7 +89,7 @@ nmap <leader>f  <Plug>(coc-format-selected)
 augroup mygroup
   autocmd!
   " Setup formatexpr specified filetype(s).
-  autocmd FileType typescript,json setl formatexpr=CocAction('formatSelected')
+  autocmd FileType scala setl formatexpr=CocAction('formatSelected')
   " Update signature help on jump placeholder
   autocmd User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')
 augroup end
@@ -105,24 +103,11 @@ nmap <leader>ac  <Plug>(coc-codeaction)
 " Fix autofix problem of current line
 nmap <leader>qf  <Plug>(coc-fix-current)
 
-" Create mappings for function text object, requires document symbols feature of languageserver.
-xmap if <Plug>(coc-funcobj-i)
-xmap af <Plug>(coc-funcobj-a)
-omap if <Plug>(coc-funcobj-i)
-omap af <Plug>(coc-funcobj-a)
-
-" Use <C-d> for select selections ranges, needs server support, like: coc-tsserver, coc-python
-nmap <silent> <C-d> <Plug>(coc-range-select)
-xmap <silent> <C-d> <Plug>(coc-range-select)
-
 " Use `:Format` to format current buffer
 command! -nargs=0 Format :call CocAction('format')
 
 " Use `:Fold` to fold current buffer
 command! -nargs=? Fold :call     CocAction('fold', <f-args>)
-
-" use `:OR` for organize import of current buffer
-command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
 
 " Add status line support, for integration with other plugin, checkout `:h coc-status`
 set statusline^=%{coc#status()}%{get(b:,'coc_current_function','')}

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,8 +143,8 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
     }
   );
 
-  trackDownloadProgress(fetchProcess).then(
-    classpath => {
+  trackDownloadProgress(fetchProcess)
+    .then(classpath => {
       launchMetals(
         context,
         javaPath,
@@ -153,19 +153,13 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
         javaOptions,
         customRepositoriesEnv
       );
-    },
-    () => {
+    })
+    .catch(err => {
       const msg = (() => {
         const proxy =
-          `See https://scalameta.org/metals/docs/editors/vscode.html#http-proxy for instructions ` +
+          `See https://scalaeta.org/metals/docs/editors/vscode.html#http-proxy for instructions ` +
           `if you are using an HTTP proxy.`;
-        if (process.env.FLATPAK_SANDBOX_DIR) {
-          return (
-            `Failed to download Metals. It seems you are running Visual Studio Code inside the ` +
-            `Flatpak sandbox, which is known to interfere with the download of Metals. ` +
-            `Please, try running Visual Studio Code without Flatpak.`
-          );
-        } else if (serverVersion === defaultServerVersion) {
+        if (serverVersion === defaultServerVersion) {
           return (
             `Failed to download Metals, make sure you have an internet connection and ` +
             `the Java Home '${javaPath}' is valid. You can configure the Java Home in the settings.` +
@@ -180,11 +174,12 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
           );
         }
       })();
-      workspace.showPrompt(msg + `\n Open Settings?`).then(choice => {
-        if (choice) workspace.nvim.command(Commands.OPEN_COC_CONFIG, true);
-      });
-    }
-  );
+      workspace
+        .showPrompt(`${err.message}\n ${msg}\n Open Settings?`)
+        .then(choice => {
+          if (choice) workspace.nvim.command(Commands.OPEN_COC_CONFIG, true);
+        });
+    });
 }
 
 function launchMetals(


### PR DESCRIPTION
This pr updates the recommended mappings document since there was some unrelated stuff in there from the coc.nvim recommended one. This also changes the `trackAndDownloadProgress` to be a bit more clear and carries the Error out to be caught and used.